### PR TITLE
SCRUM-14: We need to add validation when creating/adding a new user. Only email addresses from the @honeycombsoft.com domain should be accepted

### DIFF
--- a/api/src/application/users/dto/create-user.dto.ts
+++ b/api/src/application/users/dto/create-user.dto.ts
@@ -9,15 +9,17 @@ import {
     ArrayMinSize,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsValidEmailDomain } from '../../../domain/validators/email-domain.validator';
 
 export class CreateUserDto {
     @ApiProperty({
-        description: 'Email address of the user',
-        example: 'user@example.com',
+        description: 'Email address of the user (must be from @honeycombsoft.com domain)',
+        example: 'user@honeycombsoft.com',
         maxLength: 255,
     })
     @IsNotEmpty()
     @IsEmail()
+    @IsValidEmailDomain()
     @MaxLength(255)
     email: string;
 

--- a/api/src/domain/validators/email-domain.validator.ts
+++ b/api/src/domain/validators/email-domain.validator.ts
@@ -1,0 +1,38 @@
+import {
+    registerDecorator,
+    ValidationOptions,
+    ValidatorConstraint,
+    ValidatorConstraintInterface,
+    ValidationArguments,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'isValidEmailDomain', async: false })
+export class IsValidEmailDomainConstraint implements ValidatorConstraintInterface {
+    validate(email: string, _args: ValidationArguments) {
+        if (!email) {
+            return false;
+        }
+
+        const allowedDomain = process.env.ALLOWED_EMAIL_DOMAIN || '@honeycombsoft.com';
+
+        return email.endsWith(allowedDomain);
+    }
+
+    defaultMessage(_args: ValidationArguments) {
+        const allowedDomain = process.env.ALLOWED_EMAIL_DOMAIN || '@honeycombsoft.com';
+        return `Email must be from the ${allowedDomain} domain`;
+    }
+}
+
+export function IsValidEmailDomain(validationOptions?: ValidationOptions) {
+    return function (object: object, propertyName: string) {
+        registerDecorator({
+            name: 'isValidEmailDomain',
+            target: object.constructor,
+            propertyName: propertyName,
+            options: validationOptions,
+            constraints: [],
+            validator: IsValidEmailDomainConstraint,
+        });
+    };
+}


### PR DESCRIPTION
## Summary
- Added custom email domain validation for user creation endpoints
- Validation applies to both POST /users (regular admin) and POST /users/super (super admin) endpoints
- Uses configurable domain validation with environment variable support
- Existing users with different domains remain unchanged per requirements

## Changes Made
- Created `IsValidEmailDomain` custom validator in `src/domain/validators/email-domain.validator.ts`
- Modified `CreateUserDto` to include domain validation decorator
- Validation supports both hardcoded `@honeycombsoft.com` domain and environment variable `ALLOWED_EMAIL_DOMAIN`
- Updated API documentation and examples to reflect domain requirement

## Test plan
- [x] Code compiles successfully
- [x] Linting passes with no errors
- [x] Validation applies to both user creation endpoints through DTO inheritance
- [ ] Manual testing of user creation with valid @honeycombsoft.com emails
- [ ] Manual testing of user creation with invalid domain emails (should fail validation)
- [ ] Testing with environment variable ALLOWED_EMAIL_DOMAIN set to different domain

🤖 Generated with [Claude Code](https://claude.ai/code)