### PR TITLE
test-playground-sdk: Add light/dark theme switcher

### DIFF
--- a/client/src/common/components/MainLayout.tsx
+++ b/client/src/common/components/MainLayout.tsx
@@ -20,6 +20,7 @@ import {
 import { Theme } from '@mui/material/styles';
 import MenuIcon from '@mui/icons-material/Menu';
 import CustomUserButton from './CustomUserButton';
+import ThemeSwitcher from './ThemeSwitcher';
 import useUserRoles from '../hooks/useUserRoles';
 import { ROLES } from '../constants/roles';
 import InvoiceFileUpload from '../../modules/invoices/components/InvoiceFileUpload';
@@ -152,7 +153,8 @@ const MainLayout: React.FC = () => {
               ))}
             </Box>
 
-            <Box sx={{ ml: { xs: 1, md: 2 } }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: { xs: 1, md: 2 } }}>
+              <ThemeSwitcher />
               <CustomUserButton afterSignOutUrl="/" />
             </Box>
           </Toolbar>

--- a/client/src/common/components/ThemeSwitcher.tsx
+++ b/client/src/common/components/ThemeSwitcher.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import { Brightness4, Brightness7 } from '@mui/icons-material';
+import { useThemeMode } from '../contexts/ThemeContext';
+
+const ThemeSwitcher: React.FC = () => {
+  const { mode, toggleTheme } = useThemeMode();
+
+  return (
+    <Tooltip title={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode`}>
+      <IconButton onClick={toggleTheme} color="inherit" size="medium">
+        {mode === 'light' ? <Brightness4 /> : <Brightness7 />}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default ThemeSwitcher;

--- a/client/src/common/contexts/ThemeContext.tsx
+++ b/client/src/common/contexts/ThemeContext.tsx
@@ -1,0 +1,235 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { createTheme, ThemeProvider as MuiThemeProvider } from '@mui/material';
+
+type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextProps {
+  mode: ThemeMode;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextProps | undefined>(undefined);
+
+const THEME_STORAGE_KEY = 'theme-mode';
+
+const createAppTheme = (mode: ThemeMode) =>
+  createTheme({
+    palette: {
+      mode,
+      primary: {
+        main: '#1fb8aa',
+        light: '#3fc9bc',
+        dark: '#0d9488',
+        contrastText: mode === 'light' ? '#FFFFFF' : '#000000',
+      },
+      secondary: {
+        main: '#06b6d4',
+        light: '#22d3f1',
+        dark: '#0e7490',
+        contrastText: mode === 'light' ? '#FFFFFF' : '#000000',
+      },
+      background: {
+        default: mode === 'light' ? '#FFFFFF' : '#0F172A',
+        paper: mode === 'light' ? '#F8FAFC' : '#1E293B',
+      },
+      text: {
+        primary: mode === 'light' ? '#1E293B' : '#FFFFFF',
+        secondary: mode === 'light' ? '#64748B' : '#94A3B8',
+      },
+      error: {
+        main: '#EF4444',
+      },
+      warning: {
+        main: '#F59E0B',
+      },
+      info: {
+        main: '#3B82F6',
+      },
+      success: {
+        main: '#10B981',
+      },
+      divider: mode === 'light' ? '#E2E8F0' : '#334155',
+    },
+    typography: {
+      fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+      h1: {
+        fontWeight: 700,
+      },
+      h2: {
+        fontWeight: 700,
+      },
+      h3: {
+        fontWeight: 600,
+      },
+      h4: {
+        fontWeight: 600,
+      },
+      h5: {
+        fontWeight: 600,
+      },
+      h6: {
+        fontWeight: 600,
+      },
+      button: {
+        fontWeight: 600,
+        textTransform: 'none',
+      },
+    },
+    shape: {
+      borderRadius: 8,
+    },
+    components: {
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            borderRadius: 8,
+            boxShadow: 'none',
+            padding: '8px 16px',
+            '&:hover': {
+              boxShadow: 'none',
+            },
+          },
+          contained: {
+            background: 'linear-gradient(to right, #1fb8aa, #0d9488)',
+            '&:hover': {
+              background: 'linear-gradient(to right, #0d9488, #0f766e)',
+            },
+          },
+          outlined: {
+            borderColor: '#1fb8aa',
+            color: '#1fb8aa',
+            '&:hover': {
+              borderColor: '#0d9488',
+              color: '#0d9488',
+              backgroundColor: 'rgba(13, 148, 136, 0.04)',
+            },
+          },
+        },
+      },
+      MuiSelect: {
+        styleOverrides: {
+          root: {
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: '#1fb8aa',
+            },
+            '&:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: '#1fb8aa',
+            },
+          },
+        },
+      },
+      MuiMenuItem: {
+        styleOverrides: {
+          root: {
+            '&.Mui-selected': {
+              backgroundColor: 'rgba(31, 184, 170, 0.1)',
+            },
+            '&.Mui-selected:hover': {
+              backgroundColor: 'rgba(31, 184, 170, 0.2)',
+            },
+            '&:hover': {
+              backgroundColor: 'rgba(31, 184, 170, 0.05)',
+            },
+          },
+        },
+      },
+      MuiCard: {
+        styleOverrides: {
+          root: {
+            borderRadius: 12,
+            boxShadow:
+              mode === 'light'
+                ? '0 4px 6px rgba(0, 0, 0, 0.1)'
+                : '0 4px 6px rgba(0, 0, 0, 0.3)',
+            border: mode === 'light' ? '1px solid #E2E8F0' : '1px solid #334155',
+          },
+        },
+      },
+      MuiPaper: {
+        styleOverrides: {
+          root: {
+            backgroundImage: 'none',
+          },
+        },
+      },
+      MuiAppBar: {
+        styleOverrides: {
+          root: {
+            boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+            backgroundImage: 'none',
+          },
+        },
+      },
+      MuiTableHead: {
+        styleOverrides: {
+          root: {
+            '& .MuiTableCell-root': {
+              fontWeight: 600,
+              color: mode === 'light' ? '#1E293B' : '#FFFFFF',
+            },
+          },
+        },
+      },
+      MuiTextField: {
+        styleOverrides: {
+          root: {
+            '& .MuiOutlinedInput-root': {
+              '& fieldset': {
+                borderColor: mode === 'light' ? '#E2E8F0' : '#334155',
+              },
+              '&:hover fieldset': {
+                borderColor: '#1fb8aa',
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: '#1fb8aa',
+              },
+            },
+          },
+        },
+      },
+      MuiChip: {
+        styleOverrides: {
+          root: {
+            fontWeight: 500,
+          },
+        },
+      },
+    },
+  });
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [mode, setMode] = useState<ThemeMode>('dark');
+
+  useEffect(() => {
+    const savedMode = localStorage.getItem(THEME_STORAGE_KEY) as ThemeMode;
+    if (savedMode && (savedMode === 'light' || savedMode === 'dark')) {
+      setMode(savedMode);
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const newMode = mode === 'light' ? 'dark' : 'light';
+    setMode(newMode);
+    localStorage.setItem(THEME_STORAGE_KEY, newMode);
+  };
+
+  const theme = createAppTheme(mode);
+
+  return (
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
+      <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
+};
+
+export const useThemeMode = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useThemeMode must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,9 +5,10 @@ import { createRoot } from 'react-dom/client';
 import './styles/global.css';
 import App from './App.tsx';
 import { ClerkProvider } from '@clerk/clerk-react';
-import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+import { CssBaseline } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import clerkInstance from './common/services/clerkInstance.ts';
+import { ThemeProvider } from './common/contexts/ThemeContext.tsx';
 
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
@@ -45,192 +46,11 @@ const queryClient = new QueryClient({
   },
 });
 
-// Custom theme with invoice analytics design system
-const theme = createTheme({
-  palette: {
-    mode: 'dark',
-    primary: {
-      main: '#1fb8aa',
-      light: '#3fc9bc',
-      dark: '#0d9488',
-      contrastText: '#000000',
-    },
-    secondary: {
-      main: '#06b6d4',
-      light: '#22d3f1',
-      dark: '#0e7490',
-      contrastText: '#000000',
-    },
-    background: {
-      default: '#0F172A', // Slate-900
-      paper: '#1E293B', // Slate-800
-    },
-    text: {
-      primary: '#FFFFFF',
-      secondary: '#94A3B8', // Slate-400
-    },
-    error: {
-      main: '#EF4444', // Red-500
-    },
-    warning: {
-      main: '#F59E0B', // Amber-500
-    },
-    info: {
-      main: '#3B82F6', // Blue-500
-    },
-    success: {
-      main: '#10B981', // Emerald-500
-    },
-    divider: '#334155', // Slate-700
-  },
-  typography: {
-    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
-    h1: {
-      fontWeight: 700,
-    },
-    h2: {
-      fontWeight: 700,
-    },
-    h3: {
-      fontWeight: 600,
-    },
-    h4: {
-      fontWeight: 600,
-    },
-    h5: {
-      fontWeight: 600,
-    },
-    h6: {
-      fontWeight: 600,
-    },
-    button: {
-      fontWeight: 600,
-      textTransform: 'none',
-    },
-  },
-  shape: {
-    borderRadius: 8,
-  },
-  components: {
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          borderRadius: 8,
-          boxShadow: 'none',
-          padding: '8px 16px',
-          '&:hover': {
-            boxShadow: 'none',
-          },
-        },
-        contained: {
-          background: 'linear-gradient(to right, #1fb8aa, #0d9488)',
-          '&:hover': {
-            background: 'linear-gradient(to right, #0d9488, #0f766e)',
-          },
-        },
-        outlined: {
-          borderColor: '#1fb8aa',
-          color: '#1fb8aa',
-          '&:hover': {
-            borderColor: '#0d9488',
-            color: '#0d9488',
-            backgroundColor: 'rgba(13, 148, 136, 0.04)',
-          },
-        },
-      },
-    },
-    MuiSelect: {
-      styleOverrides: {
-        root: {
-          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#1fb8aa',
-          },
-          '&:hover .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#1fb8aa',
-          },
-        },
-      },
-    },
-    MuiMenuItem: {
-      styleOverrides: {
-        root: {
-          '&.Mui-selected': {
-            backgroundColor: 'rgba(31, 184, 170, 0.1)',
-          },
-          '&.Mui-selected:hover': {
-            backgroundColor: 'rgba(31, 184, 170, 0.2)',
-          },
-          '&:hover': {
-            backgroundColor: 'rgba(31, 184, 170, 0.05)',
-          },
-        },
-      },
-    },
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          borderRadius: 12,
-          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
-          border: '1px solid #334155',
-        },
-      },
-    },
-    MuiPaper: {
-      styleOverrides: {
-        root: {
-          backgroundImage: 'none',
-        },
-      },
-    },
-    MuiAppBar: {
-      styleOverrides: {
-        root: {
-          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-          backgroundImage: 'none',
-        },
-      },
-    },
-    MuiTableHead: {
-      styleOverrides: {
-        root: {
-          '& .MuiTableCell-root': {
-            fontWeight: 600,
-            color: '#FFFFFF',
-          },
-        },
-      },
-    },
-    MuiTextField: {
-      styleOverrides: {
-        root: {
-          '& .MuiOutlinedInput-root': {
-            '& fieldset': {
-              borderColor: '#334155',
-            },
-            '&:hover fieldset': {
-              borderColor: '#1fb8aa',
-            },
-            '&.Mui-focused fieldset': {
-              borderColor: '#1fb8aa',
-            },
-          },
-        },
-      },
-    },
-    MuiChip: {
-      styleOverrides: {
-        root: {
-          fontWeight: 500,
-        },
-      },
-    },
-  },
-});
 
 // eslint-disable-next-line react-refresh/only-export-components
 const RootComponent: React.FC = () => {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider>
       <CssBaseline />
       <SnackbarProvider>
         <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Summary

- Added a light/dark theme switcher toggle button in the top AppBar next to the user button
- Implemented `ThemeContext` with localStorage persistence for theme preference
- Created `ThemeSwitcher` component using Material-UI icons (Brightness4/Brightness7)
- Refactored hardcoded dark theme to dynamic theme system supporting both light and dark modes
- Maintained existing design system colors and styling patterns

## Implementation Details

### New Components
- `ThemeContext.tsx`: React context for theme state management with localStorage persistence
- `ThemeSwitcher.tsx`: Toggle button component with Material-UI icons and tooltip

### Modified Components
- `MainLayout.tsx`: Added theme switcher to AppBar toolbar
- `main.tsx`: Replaced static theme with dynamic ThemeProvider

### Features
- **Theme Toggle**: Click the sun/moon icon to switch between light and dark themes
- **Persistence**: Theme preference is saved to localStorage and restored on page load
- **Responsive Design**: Theme switcher maintains existing responsive behavior
- **Accessibility**: Includes tooltip indicating the action (e.g., "Switch to light mode")

## Test Plan

- [x] Theme switcher appears in AppBar next to user button
- [x] Clicking switches between light and dark themes
- [x] Theme preference persists across page refreshes
- [x] All existing functionality remains intact
- [x] Build passes without TypeScript errors
- [x] Linting passes without issues