### PR TITLE
test-playground-sdk-with-plan: Add a *theme switcher*

### DIFF
--- a/client/src/common/components/MainLayout.tsx
+++ b/client/src/common/components/MainLayout.tsx
@@ -20,6 +20,7 @@ import {
 import { Theme } from '@mui/material/styles';
 import MenuIcon from '@mui/icons-material/Menu';
 import CustomUserButton from './CustomUserButton';
+import ThemeSwitcher from './ThemeSwitcher';
 import useUserRoles from '../hooks/useUserRoles';
 import { ROLES } from '../constants/roles';
 import InvoiceFileUpload from '../../modules/invoices/components/InvoiceFileUpload';
@@ -152,7 +153,8 @@ const MainLayout: React.FC = () => {
               ))}
             </Box>
 
-            <Box sx={{ ml: { xs: 1, md: 2 } }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', ml: { xs: 1, md: 2 }, gap: 1 }}>
+              <ThemeSwitcher />
               <CustomUserButton afterSignOutUrl="/" />
             </Box>
           </Toolbar>

--- a/client/src/common/components/ThemeSwitcher.tsx
+++ b/client/src/common/components/ThemeSwitcher.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import { LightMode, DarkMode } from '@mui/icons-material';
+import { useThemeMode } from '../contexts/ThemeContext';
+
+const ThemeSwitcher: React.FC = () => {
+  const { mode, toggleTheme } = useThemeMode();
+
+  return (
+    <Tooltip title={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode`}>
+      <IconButton
+        onClick={toggleTheme}
+        color="inherit"
+        aria-label={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode`}
+        sx={{
+          color: 'text.secondary',
+          '&:hover': {
+            color: 'text.primary',
+          },
+        }}
+      >
+        {mode === 'light' ? <DarkMode /> : <LightMode />}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default ThemeSwitcher;

--- a/client/src/common/contexts/ThemeContext.tsx
+++ b/client/src/common/contexts/ThemeContext.tsx
@@ -1,0 +1,51 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+export type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextType {
+  mode: ThemeMode;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeContextProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [mode, setMode] = useState<ThemeMode>(() => {
+    try {
+      const saved = localStorage.getItem('theme-mode');
+      return (saved as ThemeMode) || 'dark';
+    } catch {
+      return 'dark';
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('theme-mode', mode);
+    } catch {
+      // Ignore localStorage errors
+    }
+  }, [mode]);
+
+  const toggleTheme = () => {
+    setMode((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useThemeMode = (): ThemeContextType => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useThemeMode must be used within a ThemeContextProvider');
+  }
+  return context;
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -8,6 +8,7 @@ import { ClerkProvider } from '@clerk/clerk-react';
 import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import clerkInstance from './common/services/clerkInstance.ts';
+import { ThemeContextProvider, useThemeMode } from './common/contexts/ThemeContext.tsx';
 
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
@@ -46,28 +47,28 @@ const queryClient = new QueryClient({
 });
 
 // Custom theme with invoice analytics design system
-const theme = createTheme({
+const createAppTheme = (mode: 'light' | 'dark') => createTheme({
   palette: {
-    mode: 'dark',
+    mode,
     primary: {
       main: '#1fb8aa',
       light: '#3fc9bc',
       dark: '#0d9488',
-      contrastText: '#000000',
+      contrastText: mode === 'light' ? '#FFFFFF' : '#000000',
     },
     secondary: {
       main: '#06b6d4',
       light: '#22d3f1',
       dark: '#0e7490',
-      contrastText: '#000000',
+      contrastText: mode === 'light' ? '#FFFFFF' : '#000000',
     },
     background: {
-      default: '#0F172A', // Slate-900
-      paper: '#1E293B', // Slate-800
+      default: mode === 'light' ? '#F8FAFC' : '#0F172A', // Slate-50 / Slate-900
+      paper: mode === 'light' ? '#FFFFFF' : '#1E293B', // White / Slate-800
     },
     text: {
-      primary: '#FFFFFF',
-      secondary: '#94A3B8', // Slate-400
+      primary: mode === 'light' ? '#0F172A' : '#FFFFFF', // Slate-900 / White
+      secondary: mode === 'light' ? '#64748B' : '#94A3B8', // Slate-500 / Slate-400
     },
     error: {
       main: '#EF4444', // Red-500
@@ -81,7 +82,7 @@ const theme = createTheme({
     success: {
       main: '#10B981', // Emerald-500
     },
-    divider: '#334155', // Slate-700
+    divider: mode === 'light' ? '#E2E8F0' : '#334155', // Slate-200 / Slate-700
   },
   typography: {
     fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
@@ -170,8 +171,8 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           borderRadius: 12,
-          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
-          border: '1px solid #334155',
+          boxShadow: mode === 'light' ? '0 4px 6px rgba(0, 0, 0, 0.1)' : '0 4px 6px rgba(0, 0, 0, 0.3)',
+          border: `1px solid ${mode === 'light' ? '#E2E8F0' : '#334155'}`,
         },
       },
     },
@@ -205,7 +206,7 @@ const theme = createTheme({
         root: {
           '& .MuiOutlinedInput-root': {
             '& fieldset': {
-              borderColor: '#334155',
+              borderColor: mode === 'light' ? '#E2E8F0' : '#334155',
             },
             '&:hover fieldset': {
               borderColor: '#1fb8aa',
@@ -227,8 +228,10 @@ const theme = createTheme({
   },
 });
 
-// eslint-disable-next-line react-refresh/only-export-components
-const RootComponent: React.FC = () => {
+const ThemedApp: React.FC = () => {
+  const { mode } = useThemeMode();
+  const theme = createAppTheme(mode);
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -240,6 +243,15 @@ const RootComponent: React.FC = () => {
         </QueryClientProvider>
       </SnackbarProvider>
     </ThemeProvider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+const RootComponent: React.FC = () => {
+  return (
+    <ThemeContextProvider>
+      <ThemedApp />
+    </ThemeContextProvider>
   );
 };
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- ✅ Added light/dark theme toggle button in AppBar next to user button
- ✅ Implemented theme persistence using localStorage
- ✅ Created dynamic theme configuration supporting both light and dark modes
- ✅ Used Material-UI icons (LightMode/DarkMode) for intuitive switching

## Changes Made
- **Theme Context**: Created `ThemeContext` with `useThemeMode` hook for state management
- **Theme Configuration**: Refactored static theme to dynamic `createAppTheme()` function
- **Theme Switcher Component**: Added accessible toggle button with tooltips and proper ARIA labels
- **AppBar Integration**: Positioned switcher next to user button with proper spacing
- **Color Scheme**: Defined comprehensive light theme with appropriate contrast ratios

## Test Plan
- [x] Build passes without errors
- [x] Theme switching works between light and dark modes
- [x] Theme preference persists across page refreshes via localStorage
- [x] Component follows existing design patterns and accessibility standards
- [x] No breaking changes to existing functionality

## Technical Details
- Uses existing MUI theming system and Material Icons
- Follows React context pattern for global state management
- Graceful fallback if localStorage is unavailable
- Maintains existing design system colors and typography
EOF
)