### PR TITLE
SCRUM-52: add cookie banner

### DIFF
--- a/landing/src/components/cookie-banner.tsx
+++ b/landing/src/components/cookie-banner.tsx
@@ -1,0 +1,40 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { useCookieConsent } from '../hooks/use-cookie-consent';
+
+export default function CookieBanner() {
+  const { showBanner, acceptCookies, rejectCookies } = useCookieConsent();
+
+  return (
+    <AnimatePresence>
+      {showBanner && (
+        <motion.div
+          initial={{ y: 100, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 100, opacity: 0 }}
+          transition={{ duration: 0.3, ease: 'easeOut' }}
+          className="fixed bottom-0 left-0 right-0 z-50 bg-slate-800 border-t border-slate-700 p-4 md:p-6"
+        >
+          <div className="container mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
+            <div className="text-white text-sm md:text-base text-center md:text-left">
+              We use cookies to improve your experience. By continuing, you accept our use of cookies.
+            </div>
+            <div className="flex gap-3 shrink-0">
+              <button
+                onClick={rejectCookies}
+                className="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white border border-slate-600 hover:border-slate-500 rounded-md transition-colors"
+              >
+                Reject All
+              </button>
+              <button
+                onClick={acceptCookies}
+                className="px-4 py-2 text-sm font-medium bg-gradient-to-r from-teal-500 to-emerald-600 hover:from-teal-600 hover:to-emerald-700 text-black rounded-md transition-colors"
+              >
+                Accept All
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/landing/src/hooks/use-cookie-consent.tsx
+++ b/landing/src/hooks/use-cookie-consent.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+
+const COOKIE_CONSENT_KEY = 'cookie-consent';
+
+type CookieConsentState = 'pending' | 'accepted' | 'rejected';
+
+export function useCookieConsent() {
+  const [consent, setConsent] = useState<CookieConsentState>('pending');
+
+  useEffect(() => {
+    try {
+      const storedConsent = localStorage.getItem(COOKIE_CONSENT_KEY);
+      if (storedConsent === 'accepted' || storedConsent === 'rejected') {
+        setConsent(storedConsent);
+      }
+    } catch {
+      // localStorage not available, keep default state
+    }
+  }, []);
+
+  const acceptCookies = () => {
+    try {
+      localStorage.setItem(COOKIE_CONSENT_KEY, 'accepted');
+      setConsent('accepted');
+    } catch {
+      // localStorage not available, only update state
+      setConsent('accepted');
+    }
+  };
+
+  const rejectCookies = () => {
+    try {
+      localStorage.setItem(COOKIE_CONSENT_KEY, 'rejected');
+      setConsent('rejected');
+    } catch {
+      // localStorage not available, only update state
+      setConsent('rejected');
+    }
+  };
+
+  return {
+    consent,
+    acceptCookies,
+    rejectCookies,
+    showBanner: consent === 'pending',
+  };
+}

--- a/landing/src/pages/index.page.tsx
+++ b/landing/src/pages/index.page.tsx
@@ -6,6 +6,7 @@ import IntegrationsIcon from '../components/svg/IntegrationsIcon';
 import ReportsIcon from '../components/svg/ReportsIcon';
 import AutomationIcon from '../components/svg/AutomationIcon';
 import DashboardIcon from '../components/svg/DashboardIcon';
+import CookieBanner from '../components/cookie-banner';
 
 export const title = 'Invoice Analytics';
 export const description = 'Gain Deep Insights into Your Invoices';
@@ -417,6 +418,7 @@ export default function LandingPage({ appUrl = '/app' }: LandingPageProps): Reac
           </div>
         </div>
       </footer>
+      <CookieBanner />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add simple notice cookie banner to landing page only
- Implement Accept/Reject buttons with localStorage persistence
- Use full-width bottom bar design with smooth animations

## Test plan
- [ ] Banner appears on fresh landing page load
- [ ] Accept All button dismisses banner and stores preference
- [ ] Reject All button dismisses banner and stores preference  
- [ ] Banner does not reappear after choice is made
- [ ] Banner is responsive across different screen sizes