### PR TITLE
TEST-0778

### DIFF
--- a/api/src/api/controllers/team.controller.ts
+++ b/api/src/api/controllers/team.controller.ts
@@ -1,0 +1,233 @@
+import {
+    Controller,
+    Get,
+    Post,
+    Body,
+    Patch,
+    Param,
+    Delete,
+    Req,
+    HttpCode,
+    HttpStatus,
+    Inject,
+    ForbiddenException,
+} from '@nestjs/common';
+
+import {
+    ITeamCommands,
+    TEAM_COMMANDS,
+} from '../../application/teams/interfaces/team-commands.interface';
+import {
+    ITeamQueries,
+    TEAM_QUERIES,
+} from '../../application/teams/interfaces/team-queries.interface';
+import { CreateTeamDto } from '../../application/teams/dto/create-team.dto';
+import { UpdateTeamDto } from '../../application/teams/dto/update-team.dto';
+import { AddMemberDto } from '../../application/teams/dto/add-member.dto';
+import { TeamDto } from '../../application/teams/dto/team.dto';
+import { RoleName } from '../../domain/enums/role-name.enum';
+import { Authorize } from '../../infrastructure/auth/decorators/authorize.decorator';
+import { RequestWithTenant } from 'src/infrastructure/middleware/request-with-tenant.interface';
+import {
+    ApiTags,
+    ApiOperation,
+    ApiResponse,
+    ApiParam,
+    ApiBearerAuth,
+    ApiBody,
+    ApiNoContentResponse,
+    ApiUnauthorizedResponse,
+    ApiForbiddenResponse,
+    ApiNotFoundResponse,
+} from '@nestjs/swagger';
+
+interface RequestingUserContext {
+    isSuperAdmin: boolean;
+    tenantId?: string;
+}
+
+@ApiTags('Teams')
+@ApiBearerAuth()
+@Controller('teams')
+@Authorize()
+export class TeamController {
+    constructor(
+        @Inject(TEAM_COMMANDS) private readonly teamCommands: ITeamCommands,
+        @Inject(TEAM_QUERIES) private readonly teamQueries: ITeamQueries,
+    ) {}
+
+    private getRequestingUserContext(req: RequestWithTenant): RequestingUserContext {
+        const isSuperAdmin: boolean = req.userRoles!.includes(RoleName.SUPER_ADMIN);
+        const tenantId: string | undefined = isSuperAdmin ? undefined : req.tenantId!;
+
+        return { isSuperAdmin, tenantId };
+    }
+
+    @Post()
+    @Authorize(RoleName.ADMIN)
+    @HttpCode(HttpStatus.CREATED)
+    @ApiOperation({ summary: 'Create a team', description: 'Creates a new team within the tenant' })
+    @ApiBody({ type: CreateTeamDto })
+    @ApiResponse({
+        status: HttpStatus.CREATED,
+        description: 'Team created successfully',
+        type: TeamDto,
+    })
+    @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+    @ApiForbiddenResponse({
+        description: 'Forbidden - requires admin role or missing tenant information',
+    })
+    async create(
+        @Body() createTeamDto: CreateTeamDto,
+        @Req() req: RequestWithTenant,
+    ): Promise<TeamDto> {
+        const tenantId = req.tenantId;
+
+        if (tenantId === undefined) {
+            throw new ForbiddenException('Admin user must belong to a tenant.');
+        }
+
+        return this.teamCommands.createTeam(createTeamDto, tenantId);
+    }
+
+    @Get()
+    @ApiOperation({
+        summary: 'Get all teams',
+        description: 'Retrieves all teams based on role permissions',
+    })
+    @ApiResponse({
+        status: HttpStatus.OK,
+        description: 'List of teams retrieved successfully',
+        type: [TeamDto],
+    })
+    @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+    @ApiForbiddenResponse({ description: 'Forbidden - missing tenant information' })
+    async findAll(@Req() req: RequestWithTenant): Promise<TeamDto[]> {
+        const { tenantId, isSuperAdmin }: RequestingUserContext =
+            this.getRequestingUserContext(req);
+
+        if (isSuperAdmin) {
+            return this.teamQueries.findAllTeams();
+        }
+
+        if (tenantId !== undefined) {
+            return this.teamQueries.findAllTeamsByTenant(tenantId);
+        }
+
+        throw new ForbiddenException('User tenant information is missing.');
+    }
+
+    @Get(':id')
+    @ApiOperation({ summary: 'Get team by ID', description: 'Retrieves a specific team by ID' })
+    @ApiParam({
+        name: 'id',
+        description: 'Team ID',
+        example: '123e4567-e89b-12d3-a456-426614174000',
+    })
+    @ApiResponse({
+        status: HttpStatus.OK,
+        description: 'Team retrieved successfully',
+        type: TeamDto,
+    })
+    @ApiNotFoundResponse({ description: 'Team not found' })
+    @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+    async findOne(@Param('id') id: string, @Req() req: RequestWithTenant): Promise<TeamDto> {
+        const { tenantId }: RequestingUserContext = this.getRequestingUserContext(req);
+
+        return this.teamQueries.findTeamById(id, tenantId);
+    }
+
+    @Patch(':id')
+    @Authorize(RoleName.ADMIN, RoleName.SUPER_ADMIN)
+    @ApiOperation({ summary: 'Update team', description: 'Updates an existing team' })
+    @ApiParam({
+        name: 'id',
+        description: 'Team ID',
+        example: '123e4567-e89b-12d3-a456-426614174000',
+    })
+    @ApiBody({ type: UpdateTeamDto })
+    @ApiResponse({ status: HttpStatus.OK, description: 'Team updated successfully', type: TeamDto })
+    @ApiNotFoundResponse({ description: 'Team not found' })
+    @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+    @ApiForbiddenResponse({ description: 'Forbidden - team not in same tenant' })
+    async update(
+        @Param('id') id: string,
+        @Body() updateTeamDto: UpdateTeamDto,
+        @Req() req: RequestWithTenant,
+    ): Promise<TeamDto> {
+        const { tenantId }: RequestingUserContext = this.getRequestingUserContext(req);
+
+        return this.teamCommands.updateTeam(id, updateTeamDto, tenantId);
+    }
+
+    @Delete(':id')
+    @Authorize(RoleName.ADMIN, RoleName.SUPER_ADMIN)
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Delete team', description: 'Deletes a team' })
+    @ApiParam({
+        name: 'id',
+        description: 'Team ID',
+        example: '123e4567-e89b-12d3-a456-426614174000',
+    })
+    @ApiNoContentResponse({ description: 'Team deleted successfully' })
+    @ApiNotFoundResponse({ description: 'Team not found' })
+    @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+    @ApiForbiddenResponse({ description: 'Forbidden - requires admin or super admin role' })
+    async remove(@Param('id') id: string, @Req() req: RequestWithTenant): Promise<void> {
+        const { tenantId }: RequestingUserContext = this.getRequestingUserContext(req);
+
+        return this.teamCommands.deleteTeam(id, tenantId);
+    }
+
+    @Post(':id/members')
+    @Authorize(RoleName.ADMIN, RoleName.SUPER_ADMIN)
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Add team member', description: 'Adds a user to a team' })
+    @ApiParam({
+        name: 'id',
+        description: 'Team ID',
+        example: '123e4567-e89b-12d3-a456-426614174000',
+    })
+    @ApiBody({ type: AddMemberDto })
+    @ApiNoContentResponse({ description: 'Member added successfully' })
+    @ApiNotFoundResponse({ description: 'Team or user not found' })
+    @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+    @ApiForbiddenResponse({ description: 'Forbidden - requires admin or super admin role' })
+    async addMember(
+        @Param('id') id: string,
+        @Body() addMemberDto: AddMemberDto,
+        @Req() req: RequestWithTenant,
+    ): Promise<void> {
+        const { tenantId }: RequestingUserContext = this.getRequestingUserContext(req);
+
+        return this.teamCommands.addMember(id, addMemberDto.userId, tenantId);
+    }
+
+    @Delete(':id/members/:userId')
+    @Authorize(RoleName.ADMIN, RoleName.SUPER_ADMIN)
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Remove team member', description: 'Removes a user from a team' })
+    @ApiParam({
+        name: 'id',
+        description: 'Team ID',
+        example: '123e4567-e89b-12d3-a456-426614174000',
+    })
+    @ApiParam({
+        name: 'userId',
+        description: 'User ID',
+        example: '123e4567-e89b-12d3-a456-426614174001',
+    })
+    @ApiNoContentResponse({ description: 'Member removed successfully' })
+    @ApiNotFoundResponse({ description: 'Team not found' })
+    @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+    @ApiForbiddenResponse({ description: 'Forbidden - requires admin or super admin role' })
+    async removeMember(
+        @Param('id') id: string,
+        @Param('userId') userId: string,
+        @Req() req: RequestWithTenant,
+    ): Promise<void> {
+        const { tenantId }: RequestingUserContext = this.getRequestingUserContext(req);
+
+        return this.teamCommands.removeMember(id, userId, tenantId);
+    }
+}

--- a/api/src/api/modules/app.module.ts
+++ b/api/src/api/modules/app.module.ts
@@ -6,10 +6,12 @@ import { AuthModule } from '../../infrastructure/auth/auth.module';
 import { TenantModule } from '../../application/tenants/tenant.module';
 import { UserModule } from '../../application/users/user.module';
 import { RolesModule } from '../../application/roles/roles.module';
+import { TeamModule } from '../../application/teams/team.module';
 import { TenantMiddleware } from '../../infrastructure/middleware/tenant.middleware';
 import { RolesController } from '../controllers/roles.controller';
 import { TenantController } from '../controllers/tenant.controller';
 import { UserController } from '../controllers/user.controller';
+import { TeamController } from '../controllers/team.controller';
 import { SecretsModule } from '../../application/secrets/secrets.module';
 import { SecretsController } from '../controllers/secrets.controller';
 import { LlmModule } from '../../infrastructure/llm/modules/llm.module';
@@ -26,6 +28,7 @@ import { InvoiceController } from '../controllers/invoice.controller';
         TenantModule,
         UserModule,
         RolesModule,
+        TeamModule,
         SecretsModule,
         LlmModule,
         InvoiceModule,
@@ -34,6 +37,7 @@ import { InvoiceController } from '../controllers/invoice.controller';
         RolesController,
         TenantController,
         UserController,
+        TeamController,
         SecretsController,
         AiController,
         InvoiceController,

--- a/api/src/application/repositories/team.repository.interface.ts
+++ b/api/src/application/repositories/team.repository.interface.ts
@@ -1,0 +1,14 @@
+import { Team } from '../../domain/entities/team.entity';
+
+export interface ITeamRepository {
+    findById(id: string, tenantId?: string): Promise<Team | null>;
+    findAllByTenantId(tenantId: string): Promise<Team[]>;
+    findAll(): Promise<Team[]>;
+    create(name: string, description: string | undefined, tenantId: string): Promise<Team>;
+    update(id: string, name?: string, description?: string): Promise<Team | null>;
+    delete(id: string): Promise<boolean>;
+    addMember(teamId: string, userId: string): Promise<void>;
+    removeMember(teamId: string, userId: string): Promise<void>;
+}
+
+export const TEAM_REPOSITORY = 'ITeamRepository';

--- a/api/src/application/teams/dto/add-member.dto.ts
+++ b/api/src/application/teams/dto/add-member.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class AddMemberDto {
+    @ApiProperty({
+        description: 'User ID to add as a team member',
+        example: '123e4567-e89b-12d3-a456-426614174000',
+    })
+    @IsUUID()
+    userId: string;
+}

--- a/api/src/application/teams/dto/create-team.dto.ts
+++ b/api/src/application/teams/dto/create-team.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, MaxLength } from 'class-validator';
+
+export class CreateTeamDto {
+    @ApiProperty({ description: 'Name of the team', example: 'Engineering Team' })
+    @IsString()
+    @MaxLength(255)
+    name: string;
+
+    @ApiProperty({
+        description: 'Description of the team',
+        required: false,
+        example: 'Team responsible for product development',
+    })
+    @IsOptional()
+    @IsString()
+    description?: string;
+}

--- a/api/src/application/teams/dto/team.dto.ts
+++ b/api/src/application/teams/dto/team.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { TenantDto } from '../../tenants/dto/tenant.dto';
+import { UserDto } from '../../users/dto/user.dto';
+
+export class TeamDto {
+    @ApiProperty({
+        description: 'Unique identifier of the team',
+        example: '123e4567-e89b-12d3-a456-426614174000',
+    })
+    id: string;
+
+    @ApiProperty({ description: 'Name of the team', example: 'Engineering Team' })
+    name: string;
+
+    @ApiProperty({
+        description: 'Description of the team',
+        required: false,
+        example: 'Team responsible for product development',
+    })
+    description?: string;
+
+    @ApiProperty({
+        description: 'Tenant the team belongs to',
+        example: { id: '123e4567-e89b-12d3-a456-426614174000', name: 'Company Name' },
+    })
+    tenant: Pick<TenantDto, 'id' | 'name'>;
+
+    @ApiProperty({
+        description: 'Members of the team',
+        type: [UserDto],
+    })
+    members: Pick<UserDto, 'id' | 'email' | 'firstName' | 'lastName'>[];
+
+    @ApiProperty({ description: 'Date when the team was created', example: '2023-01-01T12:00:00Z' })
+    createdAt: Date;
+
+    @ApiProperty({
+        description: 'Date when the team was last updated',
+        example: '2023-01-02T12:00:00Z',
+    })
+    updatedAt: Date;
+}

--- a/api/src/application/teams/dto/update-team.dto.ts
+++ b/api/src/application/teams/dto/update-team.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, MaxLength } from 'class-validator';
+
+export class UpdateTeamDto {
+    @ApiProperty({ description: 'Name of the team', required: false, example: 'Engineering Team' })
+    @IsOptional()
+    @IsString()
+    @MaxLength(255)
+    name?: string;
+
+    @ApiProperty({
+        description: 'Description of the team',
+        required: false,
+        example: 'Team responsible for product development',
+    })
+    @IsOptional()
+    @IsString()
+    description?: string;
+}

--- a/api/src/application/teams/interfaces/team-commands.interface.ts
+++ b/api/src/application/teams/interfaces/team-commands.interface.ts
@@ -1,0 +1,13 @@
+import { TeamDto } from '../dto/team.dto';
+import { CreateTeamDto } from '../dto/create-team.dto';
+import { UpdateTeamDto } from '../dto/update-team.dto';
+
+export interface ITeamCommands {
+    createTeam(dto: CreateTeamDto, tenantId: string): Promise<TeamDto>;
+    updateTeam(id: string, dto: UpdateTeamDto, tenantId?: string): Promise<TeamDto>;
+    deleteTeam(id: string, tenantId?: string): Promise<void>;
+    addMember(teamId: string, userId: string, tenantId?: string): Promise<void>;
+    removeMember(teamId: string, userId: string, tenantId?: string): Promise<void>;
+}
+
+export const TEAM_COMMANDS = 'ITeamCommands';

--- a/api/src/application/teams/interfaces/team-queries.interface.ts
+++ b/api/src/application/teams/interfaces/team-queries.interface.ts
@@ -1,0 +1,9 @@
+import { TeamDto } from '../dto/team.dto';
+
+export interface ITeamQueries {
+    findTeamById(id: string, tenantId?: string): Promise<TeamDto>;
+    findAllTeams(): Promise<TeamDto[]>;
+    findAllTeamsByTenant(tenantId: string): Promise<TeamDto[]>;
+}
+
+export const TEAM_QUERIES = 'ITeamQueries';

--- a/api/src/application/teams/team.commands.ts
+++ b/api/src/application/teams/team.commands.ts
@@ -1,0 +1,155 @@
+import {
+    Injectable,
+    Inject,
+    NotFoundException,
+    ForbiddenException,
+    Logger,
+    InternalServerErrorException,
+} from '@nestjs/common';
+import { ITeamRepository, TEAM_REPOSITORY } from '../repositories/team.repository.interface';
+import { Team } from '../../domain/entities/team.entity';
+import { ITeamCommands } from './interfaces/team-commands.interface';
+import { CreateTeamDto } from './dto/create-team.dto';
+import { UpdateTeamDto } from './dto/update-team.dto';
+import { TeamDto } from './dto/team.dto';
+import { TenantDto } from '../tenants/dto/tenant.dto';
+import { UserDto } from '../users/dto/user.dto';
+
+@Injectable()
+export class TeamCommands implements ITeamCommands {
+    private readonly logger = new Logger(TeamCommands.name);
+
+    constructor(
+        @Inject(TEAM_REPOSITORY)
+        private readonly teamRepository: ITeamRepository,
+    ) {}
+
+    private mapToDto(team: Team | null): TeamDto | null {
+        if (!team) {
+            return null;
+        }
+
+        const dto = new TeamDto();
+
+        dto.id = team.id;
+        dto.name = team.name;
+        dto.description = team.description;
+        dto.createdAt = team.createdAt;
+        dto.updatedAt = team.updatedAt;
+
+        if (team.tenant) {
+            dto.tenant = { id: team.tenant.id, name: team.tenant.name } as Pick<
+                TenantDto,
+                'id' | 'name'
+            >;
+        }
+
+        if (team.members) {
+            dto.members = team.members.map((member) => ({
+                id: member.id,
+                email: member.email,
+                firstName: member.firstName,
+                lastName: member.lastName,
+            }));
+        } else {
+            dto.members = [];
+        }
+
+        return dto;
+    }
+
+    async createTeam(dto: CreateTeamDto, tenantId: string): Promise<TeamDto> {
+        const createdTeam = await this.teamRepository.create(dto.name, dto.description, tenantId);
+
+        const teamDto = this.mapToDto(createdTeam);
+
+        if (!teamDto) {
+            this.logger.error(`Failed to map team ID ${createdTeam.id} to DTO after creation.`);
+            throw new InternalServerErrorException('Failed to map created team.');
+        }
+
+        return teamDto;
+    }
+
+    async updateTeam(id: string, dto: UpdateTeamDto, tenantId?: string): Promise<TeamDto> {
+        const teamToUpdate = await this.teamRepository.findById(id, tenantId);
+
+        if (!teamToUpdate) {
+            throw new NotFoundException(`Team with ID ${id} not found`);
+        }
+
+        if (tenantId !== undefined && teamToUpdate.tenantId !== tenantId) {
+            throw new ForbiddenException('Cannot update team from different tenant.');
+        }
+
+        const updatedTeam = await this.teamRepository.update(id, dto.name, dto.description);
+
+        if (!updatedTeam) {
+            this.logger.error(`Team update for ID ${id} returned null from repository.`);
+            throw new InternalServerErrorException('Team update failed unexpectedly.');
+        }
+
+        const updatedDto = this.mapToDto(updatedTeam);
+
+        if (!updatedDto) {
+            this.logger.error(`Failed to map updated team ID ${id} to DTO.`);
+            throw new InternalServerErrorException('Failed to map updated team.');
+        }
+
+        return updatedDto;
+    }
+
+    async deleteTeam(id: string, tenantId?: string): Promise<void> {
+        const teamToDelete = await this.teamRepository.findById(id, tenantId);
+
+        if (!teamToDelete) {
+            throw new NotFoundException(`Team with ID ${id} not found`);
+        }
+
+        if (tenantId !== undefined && teamToDelete.tenantId !== tenantId) {
+            throw new ForbiddenException('Cannot delete team from different tenant.');
+        }
+
+        const deleted = await this.teamRepository.delete(id);
+
+        if (!deleted) {
+            throw new NotFoundException(
+                `Team with ID ${id} could not be deleted, potentially already deleted.`,
+            );
+        }
+
+        this.logger.log(`Successfully deleted team ID: ${id}`);
+    }
+
+    async addMember(teamId: string, userId: string, tenantId?: string): Promise<void> {
+        const team = await this.teamRepository.findById(teamId, tenantId);
+
+        if (!team) {
+            throw new NotFoundException(`Team with ID ${teamId} not found`);
+        }
+
+        if (tenantId !== undefined && team.tenantId !== tenantId) {
+            throw new ForbiddenException('Cannot add member to team from different tenant.');
+        }
+
+        await this.teamRepository.addMember(teamId, userId);
+
+        this.logger.log(`Successfully added user ${userId} to team ${teamId}`);
+    }
+
+    async removeMember(teamId: string, userId: string, tenantId?: string): Promise<void> {
+        const team = await this.teamRepository.findById(teamId, tenantId);
+
+        if (!team) {
+            throw new NotFoundException(`Team with ID ${teamId} not found`);
+        }
+
+        if (tenantId !== undefined && team.tenantId !== tenantId) {
+            throw new ForbiddenException('Cannot remove member from team from different tenant.');
+        }
+
+        await this.teamRepository.removeMember(teamId, userId);
+
+        this.logger.log(`Successfully removed user ${userId} from team ${teamId}`);
+    }
+}

--- a/api/src/application/teams/team.module.ts
+++ b/api/src/application/teams/team.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TeamCommands } from './team.commands';
+import { TeamQueries } from './team.queries';
+import { TEAM_COMMANDS } from './interfaces/team-commands.interface';
+import { TEAM_QUERIES } from './interfaces/team-queries.interface';
+
+@Module({
+    providers: [
+        {
+            provide: TEAM_COMMANDS,
+            useClass: TeamCommands,
+        },
+        {
+            provide: TEAM_QUERIES,
+            useClass: TeamQueries,
+        },
+    ],
+    exports: [TEAM_COMMANDS, TEAM_QUERIES],
+})
+export class TeamModule {}

--- a/api/src/application/teams/team.queries.ts
+++ b/api/src/application/teams/team.queries.ts
@@ -1,0 +1,78 @@
+import {
+    Injectable,
+    Inject,
+    NotFoundException,
+    ForbiddenException,
+    Logger,
+} from '@nestjs/common';
+import { ITeamRepository, TEAM_REPOSITORY } from '../repositories/team.repository.interface';
+import { Team } from '../../domain/entities/team.entity';
+import { ITeamQueries } from './interfaces/team-queries.interface';
+import { TeamDto } from './dto/team.dto';
+import { TenantDto } from '../tenants/dto/tenant.dto';
+
+@Injectable()
+export class TeamQueries implements ITeamQueries {
+    private readonly logger = new Logger(TeamQueries.name);
+
+    constructor(
+        @Inject(TEAM_REPOSITORY)
+        private readonly teamRepository: ITeamRepository,
+    ) {}
+
+    private mapToDto(team: Team): TeamDto {
+        const dto = new TeamDto();
+
+        dto.id = team.id;
+        dto.name = team.name;
+        dto.description = team.description;
+        dto.createdAt = team.createdAt;
+        dto.updatedAt = team.updatedAt;
+
+        if (team.tenant) {
+            dto.tenant = { id: team.tenant.id, name: team.tenant.name } as Pick<
+                TenantDto,
+                'id' | 'name'
+            >;
+        }
+
+        if (team.members) {
+            dto.members = team.members.map((member) => ({
+                id: member.id,
+                email: member.email,
+                firstName: member.firstName,
+                lastName: member.lastName,
+            }));
+        } else {
+            dto.members = [];
+        }
+
+        return dto;
+    }
+
+    async findTeamById(id: string, tenantId?: string): Promise<TeamDto> {
+        const team = await this.teamRepository.findById(id, tenantId);
+
+        if (!team) {
+            throw new NotFoundException(`Team with ID ${id} not found`);
+        }
+
+        if (tenantId !== undefined && team.tenantId !== tenantId) {
+            throw new ForbiddenException('Cannot access team from different tenant.');
+        }
+
+        return this.mapToDto(team);
+    }
+
+    async findAllTeams(): Promise<TeamDto[]> {
+        const teams = await this.teamRepository.findAll();
+
+        return teams.map((team) => this.mapToDto(team));
+    }
+
+    async findAllTeamsByTenant(tenantId: string): Promise<TeamDto[]> {
+        const teams = await this.teamRepository.findAllByTenantId(tenantId);
+
+        return teams.map((team) => this.mapToDto(team));
+    }
+}

--- a/api/src/domain/entities/team.entity.ts
+++ b/api/src/domain/entities/team.entity.ts
@@ -1,0 +1,51 @@
+import {
+    Entity,
+    Column,
+    PrimaryGeneratedColumn,
+    ManyToOne,
+    JoinColumn,
+    ManyToMany,
+    JoinTable,
+    CreateDateColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { Tenant } from './tenant.entity';
+import { User } from './user.entity';
+
+@Entity('teams')
+export class Team {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ length: 255 })
+    name: string;
+
+    @Column({ type: 'text', nullable: true })
+    description?: string;
+
+    @Column({ name: 'tenant_id' })
+    tenantId: string;
+
+    @ManyToOne(() => Tenant, {
+        onDelete: 'CASCADE',
+        nullable: false,
+    })
+    @JoinColumn({ name: 'tenant_id' })
+    tenant: Tenant;
+
+    @ManyToMany(() => User, {
+        cascade: false,
+    })
+    @JoinTable({
+        name: 'team_members',
+        joinColumn: { name: 'team_id', referencedColumnName: 'id' },
+        inverseJoinColumn: { name: 'user_id', referencedColumnName: 'id' },
+    })
+    members: User[];
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/api/src/infrastructure/persistence/migrations/1748425994517-CreateTeamsTables.ts
+++ b/api/src/infrastructure/persistence/migrations/1748425994517-CreateTeamsTables.ts
@@ -1,0 +1,63 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTeamsTables1748425994517 implements MigrationInterface {
+    name = 'CreateTeamsTables1748425994517';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS "teams" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying(255) NOT NULL, "description" text, "tenant_id" uuid NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_7e5523774a38b08a6236d322403" PRIMARY KEY ("id"))`,
+        );
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS "team_members" ("team_id" uuid NOT NULL, "user_id" uuid NOT NULL, CONSTRAINT "PK_team_members" PRIMARY KEY ("team_id", "user_id"))`,
+        );
+        await queryRunner.query(
+            `CREATE INDEX IF NOT EXISTS "IDX_team_members_team_id" ON "team_members" ("team_id")`,
+        );
+        await queryRunner.query(
+            `CREATE INDEX IF NOT EXISTS "IDX_team_members_user_id" ON "team_members" ("user_id")`,
+        );
+        await queryRunner.query(
+            `DO $$ BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint WHERE conname = 'FK_teams_tenant_id'
+                ) THEN
+                    ALTER TABLE "teams" ADD CONSTRAINT "FK_teams_tenant_id" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+                END IF;
+            END $$;`,
+        );
+        await queryRunner.query(
+            `DO $$ BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint WHERE conname = 'FK_team_members_team_id'
+                ) THEN
+                    ALTER TABLE "team_members" ADD CONSTRAINT "FK_team_members_team_id" FOREIGN KEY ("team_id") REFERENCES "teams"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+                END IF;
+            END $$;`,
+        );
+        await queryRunner.query(
+            `DO $$ BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint WHERE conname = 'FK_team_members_user_id'
+                ) THEN
+                    ALTER TABLE "team_members" ADD CONSTRAINT "FK_team_members_user_id" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+                END IF;
+            END $$;`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "team_members" DROP CONSTRAINT IF EXISTS "FK_team_members_user_id"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "team_members" DROP CONSTRAINT IF EXISTS "FK_team_members_team_id"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "teams" DROP CONSTRAINT IF EXISTS "FK_teams_tenant_id"`,
+        );
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_team_members_user_id"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_team_members_team_id"`);
+        await queryRunner.query(`DROP TABLE IF EXISTS "team_members"`);
+        await queryRunner.query(`DROP TABLE IF EXISTS "teams"`);
+    }
+}

--- a/api/src/infrastructure/persistence/persistence.module.ts
+++ b/api/src/infrastructure/persistence/persistence.module.ts
@@ -4,15 +4,18 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Tenant } from '../../domain/entities/tenant.entity';
 import { Role } from '../../domain/entities/role.entity';
 import { User } from '../../domain/entities/user.entity';
+import { Team } from '../../domain/entities/team.entity';
 import { TenantRepository } from './repositories/tenant.repository';
 import { RoleRepository } from './repositories/role.repository';
 import { UserRepository } from './repositories/user.repository';
+import { TeamRepository } from './repositories/team.repository';
 import { getTypeOrmConfig } from './typeorm.config';
 import { TENANT_REPOSITORY } from '../../application/repositories/tenant.repository.interface';
 import { ROLE_REPOSITORY } from '../../application/repositories/role.repository.interface';
 import { USER_REPOSITORY } from '../../application/repositories/user.repository.interface';
+import { TEAM_REPOSITORY } from '../../application/repositories/team.repository.interface';
 
-const entities = [Tenant, Role, User];
+const entities = [Tenant, Role, User, Team];
 
 const providers = [
     {
@@ -26,6 +29,10 @@ const providers = [
     {
         provide: USER_REPOSITORY,
         useClass: UserRepository,
+    },
+    {
+        provide: TEAM_REPOSITORY,
+        useClass: TeamRepository,
     },
 ];
 

--- a/api/src/infrastructure/persistence/repositories/team.repository.ts
+++ b/api/src/infrastructure/persistence/repositories/team.repository.ts
@@ -1,0 +1,127 @@
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Team } from '../../../domain/entities/team.entity';
+import { User } from '../../../domain/entities/user.entity';
+import { ITeamRepository } from '../../../application/repositories/team.repository.interface';
+
+@Injectable()
+export class TeamRepository implements ITeamRepository {
+    private readonly logger = new Logger(TeamRepository.name);
+
+    constructor(
+        @InjectRepository(Team)
+        private readonly ormRepository: Repository<Team>,
+        @InjectRepository(User)
+        private readonly userRepository: Repository<User>,
+    ) {}
+
+    async findById(id: string, tenantId?: string): Promise<Team | null> {
+        const whereClause: { id: string; tenantId?: string } = { id };
+        
+        if (tenantId !== undefined) {
+            whereClause.tenantId = tenantId;
+        }
+
+        return this.ormRepository.findOne({
+            where: whereClause,
+            relations: ['tenant', 'members'],
+        });
+    }
+
+    async findAllByTenantId(tenantId: string): Promise<Team[]> {
+        return this.ormRepository.find({
+            where: { tenantId },
+            relations: ['tenant', 'members'],
+        });
+    }
+
+    async findAll(): Promise<Team[]> {
+        return this.ormRepository.find({
+            relations: ['tenant', 'members'],
+        });
+    }
+
+    async create(name: string, description: string | undefined, tenantId: string): Promise<Team> {
+        const team = this.ormRepository.create({
+            name,
+            description,
+            tenantId,
+            members: [],
+        });
+
+        return await this.ormRepository.save(team);
+    }
+
+    async update(id: string, name?: string, description?: string): Promise<Team | null> {
+        const team = await this.ormRepository.findOne({
+            where: { id },
+            relations: ['tenant', 'members'],
+        });
+
+        if (!team) {
+            this.logger.warn(`Team with ID ${id} not found for update.`);
+            return null;
+        }
+
+        if (name !== undefined) {
+            team.name = name;
+        }
+
+        if (description !== undefined) {
+            team.description = description;
+        }
+
+        return await this.ormRepository.save(team);
+    }
+
+    async delete(id: string): Promise<boolean> {
+        const result = await this.ormRepository.delete(id);
+
+        return !!result?.affected && result.affected > 0;
+    }
+
+    async addMember(teamId: string, userId: string): Promise<void> {
+        const team = await this.ormRepository.findOne({
+            where: { id: teamId },
+            relations: ['members'],
+        });
+
+        if (!team) {
+            throw new NotFoundException(`Team with ID ${teamId} not found`);
+        }
+
+        const user = await this.userRepository.findOne({
+            where: { id: userId },
+        });
+
+        if (!user) {
+            throw new NotFoundException(`User with ID ${userId} not found`);
+        }
+
+        if (user.tenantId !== team.tenantId) {
+            throw new Error('User and team must belong to the same tenant');
+        }
+
+        const isAlreadyMember = team.members.some((member) => member.id === userId);
+
+        if (!isAlreadyMember) {
+            team.members.push(user);
+            await this.ormRepository.save(team);
+        }
+    }
+
+    async removeMember(teamId: string, userId: string): Promise<void> {
+        const team = await this.ormRepository.findOne({
+            where: { id: teamId },
+            relations: ['members'],
+        });
+
+        if (!team) {
+            throw new NotFoundException(`Team with ID ${teamId} not found`);
+        }
+
+        team.members = team.members.filter((member) => member.id !== userId);
+        await this.ormRepository.save(team);
+    }
+}

--- a/client/src/common/components/MainLayout.tsx
+++ b/client/src/common/components/MainLayout.tsx
@@ -47,6 +47,7 @@ const MainLayout: React.FC = () => {
     { label: 'Invoices', path: '/invoice-management', roles: [ROLES.SUPER_ADMIN] },
     { label: 'Tenants', path: '/tenant-management', roles: [ROLES.SUPER_ADMIN] },
     { label: 'Users', path: '/user-management', roles: [ROLES.ADMIN, ROLES.SUPER_ADMIN] },
+    { label: 'Teams', path: '/team-management', roles: [ROLES.ADMIN, ROLES.SUPER_ADMIN] },
     { label: 'Secrets', path: '/secrets', roles: [ROLES.ADMIN] },
   ];
 

--- a/client/src/modules/teams/components/TeamForm.tsx
+++ b/client/src/modules/teams/components/TeamForm.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { Formik, Form, Field } from 'formik';
+import { useSnackbar } from 'notistack';
+import * as Yup from 'yup';
+import {
+  TextField,
+  Button,
+  Box,
+  CircularProgress,
+  useTheme,
+} from '@mui/material';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Team } from '../types/team';
+import {
+  createTeam,
+  updateTeam,
+  CreateTeamRequest,
+  UpdateTeamPayload,
+} from '../teamMutations';
+import { TEAM_QUERY_KEYS } from '../teamQueryKeys';
+
+type TeamFormProps = {
+  team?: Team | null;
+  onClose: () => void;
+};
+
+type TeamFormValues = {
+  name: string;
+  description: string;
+};
+
+const teamSchema = Yup.object().shape({
+  name: Yup.string().max(255, 'Too Long!').required('Required'),
+  description: Yup.string().optional(),
+});
+
+const TeamForm: React.FC<TeamFormProps> = ({ team, onClose }) => {
+  const theme = useTheme();
+  const queryClient = useQueryClient();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const isEditing = !!team;
+
+  const createMutation = useMutation({
+    mutationFn: createTeam,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [TEAM_QUERY_KEYS.GET_TEAMS] });
+      enqueueSnackbar('Team created successfully', { variant: 'success' });
+      onClose();
+    },
+    onError: () => {
+      enqueueSnackbar('Failed to create team', { variant: 'error' });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: updateTeam,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [TEAM_QUERY_KEYS.GET_TEAMS] });
+      enqueueSnackbar('Team updated successfully', { variant: 'success' });
+      onClose();
+    },
+    onError: () => {
+      enqueueSnackbar('Failed to update team', { variant: 'error' });
+    },
+  });
+
+  const initialValues: TeamFormValues = {
+    name: team?.name || '',
+    description: team?.description || '',
+  };
+
+  const handleSubmit = (values: TeamFormValues) => {
+    if (isEditing && team) {
+      const payload: UpdateTeamPayload = {
+        id: team.id,
+        data: {
+          name: values.name,
+          description: values.description || undefined,
+        },
+      };
+      updateMutation.mutate(payload);
+    } else {
+      const payload: CreateTeamRequest = {
+        name: values.name,
+        description: values.description || undefined,
+      };
+      createMutation.mutate(payload);
+    }
+  };
+
+  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={teamSchema}
+      onSubmit={handleSubmit}
+      enableReinitialize
+    >
+      {({ values, errors, touched, handleChange, handleBlur }) => (
+        <Form>
+          <Box display="flex" flexDirection="column" gap={2}>
+            <Field
+              as={TextField}
+              name="name"
+              label="Team Name"
+              fullWidth
+              required
+              value={values.name}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              error={touched.name && !!errors.name}
+              helperText={touched.name && errors.name}
+              disabled={isSubmitting}
+            />
+
+            <Field
+              as={TextField}
+              name="description"
+              label="Description"
+              fullWidth
+              multiline
+              rows={4}
+              value={values.description}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              error={touched.description && !!errors.description}
+              helperText={touched.description && errors.description}
+              disabled={isSubmitting}
+            />
+
+            <Box display="flex" justifyContent="flex-end" gap={2}>
+              <Button
+                onClick={onClose}
+                disabled={isSubmitting}
+                sx={{
+                  color: theme.palette.text.primary,
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="contained"
+                disabled={isSubmitting}
+                startIcon={isSubmitting && <CircularProgress size={20} />}
+              >
+                {isEditing ? 'Update' : 'Create'}
+              </Button>
+            </Box>
+          </Box>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default TeamForm;

--- a/client/src/modules/teams/components/team-management/TeamManagementPage.tsx
+++ b/client/src/modules/teams/components/team-management/TeamManagementPage.tsx
@@ -1,0 +1,254 @@
+import React, { useEffect } from 'react';
+import { useSnackbar } from 'notistack';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import GroupIcon from '@mui/icons-material/Group';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Team } from '../../types/team';
+import TeamForm from '../TeamForm';
+import ConfirmationDialog from '../../../../common/components/ConfirmationDialog';
+import { getTeams } from '../../teamQueries';
+import { deleteTeam } from '../../teamMutations';
+import { CACHE_TIMES } from '../../../../common/constants/cacheTimes';
+import { useTeamManagementStore } from '../../stores/teamManagementStore';
+import { TEAM_QUERY_KEYS } from '../../teamQueryKeys';
+
+type TeamManagementPageProps = Record<string, unknown>;
+
+const TeamManagementPage: React.FC<TeamManagementPageProps> = () => {
+  const { enqueueSnackbar } = useSnackbar();
+  const queryClient = useQueryClient();
+  const theme = useTheme();
+
+  const {
+    isFormOpen,
+    selectedTeam,
+    isConfirmDeleteDialogOpen,
+    teamToDeleteId,
+    openCreateForm,
+    openEditForm,
+    closeForm,
+    openConfirmDeleteDialog,
+    closeConfirmDeleteDialog,
+    resetDeleteState,
+  } = useTeamManagementStore();
+
+  const {
+    data: teamsData,
+    isLoading,
+    error: teamsError,
+  } = useQuery({
+    queryKey: [TEAM_QUERY_KEYS.GET_TEAMS],
+    queryFn: getTeams,
+    staleTime: CACHE_TIMES.DEFAULT,
+  });
+
+  useEffect(() => {
+    if (teamsError) {
+      enqueueSnackbar(teamsError.message || 'An error occurred while fetching data', {
+        variant: 'error',
+      });
+    }
+  }, [teamsError, enqueueSnackbar]);
+
+  const teams: Team[] = teamsData?.data ?? [];
+
+  const { mutateAsync: removeTeamMutate, isPending: isDeleting } = useMutation({
+    mutationFn: deleteTeam,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [TEAM_QUERY_KEYS.GET_TEAMS] });
+      enqueueSnackbar('Team deleted successfully', { variant: 'success' });
+    },
+    onError: (err: Error) => {
+      enqueueSnackbar(err.message || 'Failed to delete team', {
+        variant: 'error',
+      });
+    },
+    onSettled: () => resetDeleteState(),
+  });
+
+  const handleConfirmDelete = async (): Promise<void> => {
+    if (teamToDeleteId === null) return;
+
+    await removeTeamMutate(teamToDeleteId);
+  };
+
+  const formatDate = (dateString: string | undefined): string => {
+    if (!dateString) return '-';
+
+    try {
+      return new Date(dateString).toLocaleDateString();
+    } catch {
+      return 'Invalid Date';
+    }
+  };
+
+  return (
+    <Box sx={{ backgroundColor: theme.palette.background.default }}>
+      <Card
+        sx={{
+          backgroundColor: theme.palette.background.paper,
+          color: theme.palette.text.primary,
+          overflow: 'hidden',
+        }}>
+        <CardHeader
+          title={
+            <Typography variant="h5" component="h1" sx={{ fontWeight: 'bold' }}>
+              Team Management
+            </Typography>
+          }
+          action={
+            <Button
+              variant="contained"
+              onClick={openCreateForm}
+              sx={{
+                backgroundColor: theme.palette.primary.main,
+                '&:hover': { backgroundColor: theme.palette.primary.dark },
+              }}>
+              + Add Team
+            </Button>
+          }
+        />
+        <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+          {isLoading && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', my: 5 }}>
+              <CircularProgress />
+            </Box>
+          )}
+          {!isLoading && (
+            <TableContainer>
+              <Table stickyHeader aria-label="team table">
+                <TableHead>
+                  <TableRow
+                    sx={{
+                      '& th': {
+                        backgroundColor: theme.palette.action.hover,
+                        color: theme.palette.text.secondary,
+                        fontWeight: 'bold',
+                        borderBottom: `1px solid ${theme.palette.divider}`,
+                      },
+                    }}>
+                    <TableCell>Name</TableCell>
+                    <TableCell>Description</TableCell>
+                    <TableCell>Members</TableCell>
+                    <TableCell>Created At</TableCell>
+                    <TableCell align="right">Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody
+                  sx={{
+                    '& tr': {
+                      '&:hover': {},
+                    },
+                    '& td, & th': {
+                      color: theme.palette.text.primary,
+                      borderBottom: `1px solid ${theme.palette.divider}`,
+                      py: 1,
+                    },
+                    '& tr:last-child td, & tr:last-child th': {
+                      borderBottom: 0,
+                    },
+                  }}>
+                  {teams.length === 0 && !isLoading && (
+                    <TableRow>
+                      <TableCell colSpan={5} align="center" sx={{ py: 3 }}>
+                        No teams found.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {teams.map((team) => (
+                    <TableRow key={team.id}>
+                      <TableCell component="th" scope="row">
+                        {team.name}
+                      </TableCell>
+                      <TableCell>{team.description || '-'}</TableCell>
+                      <TableCell>
+                        <Box display="flex" alignItems="center" gap={1}>
+                          <GroupIcon fontSize="small" />
+                          {team.members.length}
+                        </Box>
+                      </TableCell>
+                      <TableCell>{formatDate(team.createdAt)}</TableCell>
+                      <TableCell align="right">
+                        <Tooltip title="Edit Team">
+                          <IconButton
+                            onClick={() => openEditForm(team)}
+                            size="small"
+                            color="primary"
+                            sx={{ mr: 0.5 }}>
+                            <EditIcon />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Delete Team">
+                          <IconButton
+                            onClick={() => openConfirmDeleteDialog(team.id)}
+                            size="small"
+                            color="error"
+                            disabled={isDeleting && teamToDeleteId === team.id}>
+                            <DeleteIcon />
+                          </IconButton>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog
+        open={isFormOpen}
+        onClose={closeForm}
+        maxWidth="md"
+        fullWidth
+        PaperProps={{
+          sx: {
+            backgroundColor: theme.palette.background.paper,
+            color: theme.palette.text.primary,
+          },
+        }}>
+        <DialogTitle sx={{ borderBottom: `1px solid ${theme.palette.divider}` }}>
+          {selectedTeam ? 'Edit Team' : 'Create New Team'}
+        </DialogTitle>
+        <DialogContent sx={{ pt: 2 }}>
+          <TeamForm team={selectedTeam} onClose={closeForm} />
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmationDialog
+        open={isConfirmDeleteDialogOpen}
+        onClose={closeConfirmDeleteDialog}
+        onConfirm={handleConfirmDelete}
+        title="Delete Team"
+        message={`Are you sure you want to delete this team? This action cannot be undone.`}
+        confirmText="Delete"
+        confirmButtonProps={{ color: 'error', disabled: isDeleting }}
+      />
+    </Box>
+  );
+};
+
+export default TeamManagementPage;

--- a/client/src/modules/teams/stores/teamManagementStore.ts
+++ b/client/src/modules/teams/stores/teamManagementStore.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+import { Team } from '../types/team';
+
+interface TeamManagementState {
+  isFormOpen: boolean;
+  selectedTeam: Team | null;
+  isConfirmDeleteDialogOpen: boolean;
+  teamToDeleteId: string | null;
+  isMemberManagementOpen: boolean;
+  teamForMemberManagement: Team | null;
+
+  openCreateForm: () => void;
+  openEditForm: (team: Team) => void;
+  closeForm: () => void;
+
+  openConfirmDeleteDialog: (id: string) => void;
+  closeConfirmDeleteDialog: () => void;
+  resetDeleteState: () => void;
+
+  openMemberManagement: (team: Team) => void;
+  closeMemberManagement: () => void;
+}
+
+export const useTeamManagementStore = create<TeamManagementState>((set) => ({
+  isFormOpen: false,
+  selectedTeam: null,
+  isConfirmDeleteDialogOpen: false,
+  teamToDeleteId: null,
+  isMemberManagementOpen: false,
+  teamForMemberManagement: null,
+
+  openCreateForm: (): void => set({ isFormOpen: true, selectedTeam: null }),
+  openEditForm: (team: Team): void => set({ isFormOpen: true, selectedTeam: team }),
+  closeForm: (): void => set({ isFormOpen: false, selectedTeam: null }),
+
+  openConfirmDeleteDialog: (id: string): void =>
+    set({ isConfirmDeleteDialogOpen: true, teamToDeleteId: id }),
+  closeConfirmDeleteDialog: (): void =>
+    set({ isConfirmDeleteDialogOpen: false, teamToDeleteId: null }),
+  resetDeleteState: (): void => set({ isConfirmDeleteDialogOpen: false, teamToDeleteId: null }),
+
+  openMemberManagement: (team: Team): void =>
+    set({ isMemberManagementOpen: true, teamForMemberManagement: team }),
+  closeMemberManagement: (): void =>
+    set({ isMemberManagementOpen: false, teamForMemberManagement: null }),
+}));

--- a/client/src/modules/teams/teamMutations.ts
+++ b/client/src/modules/teams/teamMutations.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { Team, CreateTeamRequest, UpdateTeamRequest, AddMemberRequest } from './types/team';
+
+export type UpdateTeamPayload = {
+  id: string;
+  data: UpdateTeamRequest;
+};
+
+export type AddMemberPayload = {
+  teamId: string;
+  data: AddMemberRequest;
+};
+
+export type RemoveMemberPayload = {
+  teamId: string;
+  userId: string;
+};
+
+export const createTeam = (teamData: CreateTeamRequest) => axios.post<Team>('/teams', teamData);
+
+export const updateTeam = (teamPayload: UpdateTeamPayload) =>
+  axios.patch<Team>(`/teams/${teamPayload.id}`, teamPayload.data);
+
+export const deleteTeam = (id: string) => axios.delete(`/teams/${id}`);
+
+export const addTeamMember = (payload: AddMemberPayload) =>
+  axios.post(`/teams/${payload.teamId}/members`, payload.data);
+
+export const removeTeamMember = (payload: RemoveMemberPayload) =>
+  axios.delete(`/teams/${payload.teamId}/members/${payload.userId}`);

--- a/client/src/modules/teams/teamQueries.ts
+++ b/client/src/modules/teams/teamQueries.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+import { Team } from './types/team';
+
+export const getTeams = () => axios.get<Team[]>('/teams');
+export const getTeamById = (id: string) => axios.get<Team>(`/teams/${id}`);

--- a/client/src/modules/teams/teamQueryKeys.ts
+++ b/client/src/modules/teams/teamQueryKeys.ts
@@ -1,0 +1,4 @@
+export const TEAM_QUERY_KEYS = {
+  GET_TEAMS: 'get-teams',
+  GET_TEAM_BY_ID: 'get-team-by-id',
+} as const;

--- a/client/src/modules/teams/types/team.ts
+++ b/client/src/modules/teams/types/team.ts
@@ -1,0 +1,33 @@
+export type TeamMember = {
+  id: string;
+  email: string;
+  firstName?: string;
+  lastName?: string;
+};
+
+export type Team = {
+  id: string;
+  name: string;
+  description?: string;
+  tenant: {
+    id: string;
+    name: string;
+  };
+  members: TeamMember[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateTeamRequest = {
+  name: string;
+  description?: string;
+};
+
+export type UpdateTeamRequest = {
+  name?: string;
+  description?: string;
+};
+
+export type AddMemberRequest = {
+  userId: string;
+};

--- a/client/src/routes/AppRoutes.tsx
+++ b/client/src/routes/AppRoutes.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter as Router, Route, Routes, Navigate } from 'react-router-dom';
 import TenantManagementPage from '../modules/tenants/tenant-management/TenantManagementPage';
 import UserManagementPage from '../modules/users/user-management/UserManagementPage';
+import TeamManagementPage from '../modules/teams/components/team-management/TeamManagementPage';
 import MainLayout from '../common/components/MainLayout';
 import SecretsPage from '../modules/secrets/components/SecretsPage';
 import ProtectedRoute from '../common/components/ProtectedRoute';
@@ -22,6 +23,7 @@ const AppRoutes: React.FC = () => {
           </Route>
           <Route element={<ProtectedRoute requiredRoles={[ROLES.ADMIN, ROLES.SUPER_ADMIN]} />}>
             <Route path="/user-management" element={<UserManagementPage />} />
+            <Route path="/team-management" element={<TeamManagementPage />} />
           </Route>
           <Route element={<ProtectedRoute requiredRoles={[ROLES.ADMIN]} />}>
             <Route path="/secrets" element={<SecretsPage />} />


### PR DESCRIPTION
Implementation of TEST-0778


Teams Configuration

--- Additional Context from User Q&A ---

**Q:** What exactly is a 'Team' in this application? How does it relate to existing entities (Tenant, User, Role)? (A group of users within a single tenant (sub-organization), A cross-tenant collaboration group, An alternative to tenants for user organization, Something else entirely)
**A:** (A group of users within a single tenant (sub-organization)

**Q:** What configuration capabilities should Teams have? (Basic CRUD only (create, read, update, delete teams), CRUD plus member management (add/remove users to teams), Full configuration including team settings, permissions, and hierarchies, Integration with invoice/role management)
**A:** Basic CRUD only (create, read, update, delete teams), CRUD plus member management (add/remove users to teams)

**Q:** What properties should a Team entity have? (Minimal: name, description, members, Standard: name, description, members, team lead/owner, creation date, Extended: name, description, members, roles, permissions, settings, metadata)
**A:** Minimal: name, description, members

**Q:** Should there be a dedicated Team Management page in the UI, or should this be integrated into existing pages? (New dedicated Team Management page (similar to User/Tenant management), Integrate into User Management page, Integrate into Tenant Management page, API-only, no UI needed)
**A:** New dedicated Team Management page (similar to User/Tenant management)

--- Implementation Plan ---

 Implementation Plan

## Conceptual Checklist
1. Create Team entity following existing entity patterns
2. Create database migration (idempotent)
3. Implement repository layer (interface + implementation)
4. Implement application layer (commands, queries, DTOs, module)
5. Create API controller with Swagger docs
6. Build client-side infrastructure (types, API calls, store)
7. Create UI components (form, management page)
8. Configure routing

## Assumptions and Rules from CLAUDE.md
- Clean architecture: domain → application → infrastructure → api
- No comments in code (self-documenting)
- kebab-case for files, PascalCase for classes
- TypeORM for database with UUID primary keys
- Teams scoped to tenant (multi-tenancy aware)
- ADMIN and SUPER_ADMIN can manage teams
- Member management = add/remove users to teams

## Step-by-Step Implementation

### Backend
1. **Team Entity** (`api/src/domain/entities/team.entity.ts`)
   - UUID primary key, name, description columns
   - ManyToOne Tenant relationship, ManyToMany User relationship
   - tenantId foreign key

2. **Database Migration**
   - Create `teams` table with IF NOT EXISTS
   - Create `team_members` join table for User relationship

3. **Repository Layer**
   - `api/src/application/repositories/team.repository.interface.ts`
   - `api/src/infrastructure/persistence/repositories/team.repository.ts`

4. **Application Layer** (`api/src/application/teams/`)
   - DTOs: create-team.dto.ts, update-team.dto.ts, team.dto.ts
   - Interfaces: team-commands.interface.ts, team-queries.interface.ts
   - Services: team.commands.ts, team.queries.ts
   - Module: team.module.ts

5. **API Controller** (`api/src/api/controllers/team.controller.ts`)
   - CRUD endpoints + member management
   - POST /teams, GET /teams, GET /teams/:id, PATCH /teams/:id, DELETE /teams/:id
   - POST /teams/:id/members, DELETE /teams/:id/members/:userId

### Frontend
6. **Client Types & API** (`client/src/modules/teams/`)
   - types/team.ts, teamQueries.ts, teamMutations.ts, teamQueryKeys.ts

7. **State Management**
   - stores/teamManagementStore.ts (Zustand)

8. **UI Components**
   - components/TeamForm.tsx, team-management/TeamManagementPage.tsx

9. **Routing** - Add /team-management route

## Build and Verification
- `cd api && npm run lint && npm run build`
- `cd client && npm run lint && npm run build`
- Run migration: `npm run migration:run`

## Success Criteria
- [ ] Team CRUD works via API
- [ ] Member add/remove works
- [ ] UI displays teams table with actions
- [ ] Multi-tenancy properly enforced
- [ ] Migrations are idempotent
